### PR TITLE
compress image before saving to db

### DIFF
--- a/apigateway/internal/config/config.example.yml
+++ b/apigateway/internal/config/config.example.yml
@@ -14,7 +14,3 @@ grpc:
     addr: localhost:3003
   payment:
     addr: localhost:3004
-oauth:
-  client_id:
-  client_secret:
-  redirect_url: http://localhost:8080/api/v1/auth/google/callback

--- a/apigateway/internal/utils/image_jpg.go
+++ b/apigateway/internal/utils/image_jpg.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/jpeg"
+
+	"github.com/GrabItYourself/giys-backend/lib/logger"
+	"github.com/nfnt/resize"
+	"github.com/oliamb/cutter"
+	"github.com/pkg/errors"
+)
+
+func CompressImage(buffer string) (string, error) {
+
+	decoded, err := base64.StdEncoding.DecodeString(buffer)
+	if err != nil {
+		return "", errors.Wrap(err, "can't decode base64 image")
+	}
+	logger.Info(fmt.Sprintf("len (pre): %d", len(decoded)))
+
+	img, _, err := image.Decode(bytes.NewReader(decoded))
+	if err != nil {
+		return "", errors.Wrap(err, "can't create image from bytes")
+	}
+	logger.Info(fmt.Sprintf("(pre) width: %d, height: %d", img.Bounds().Dx(), img.Bounds().Dy()))
+
+	img, err = cutter.Crop(img, cutter.Config{
+		Width:   1,
+		Height:  1,
+		Mode:    cutter.Centered,
+		Options: cutter.Ratio,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "can't crop image")
+	}
+
+	img = resize.Thumbnail(500, 500, img, resize.Lanczos3)
+	logger.Info(fmt.Sprintf("(post) width: %d, height: %d", img.Bounds().Dx(), img.Bounds().Dy()))
+
+	var buf bytes.Buffer
+
+	err = jpeg.Encode(&buf, img, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "can't encode image as jpg")
+	}
+	logger.Info(fmt.Sprintf("len (post): %d", len(buf.Bytes())))
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}

--- a/apigateway/internal/utils/image_jpg.go
+++ b/apigateway/internal/utils/image_jpg.go
@@ -14,18 +14,17 @@ import (
 )
 
 func CompressImage(buffer string) (string, error) {
-
 	decoded, err := base64.StdEncoding.DecodeString(buffer)
 	if err != nil {
 		return "", errors.Wrap(err, "can't decode base64 image")
 	}
-	logger.Info(fmt.Sprintf("len (pre): %d", len(decoded)))
+	logger.Debug(fmt.Sprintf("(image) (pre) len: %d", len(decoded)))
 
 	img, _, err := image.Decode(bytes.NewReader(decoded))
 	if err != nil {
 		return "", errors.Wrap(err, "can't create image from bytes")
 	}
-	logger.Info(fmt.Sprintf("(pre) width: %d, height: %d", img.Bounds().Dx(), img.Bounds().Dy()))
+	logger.Debug(fmt.Sprintf("(image) (pre) width: %d, height: %d", img.Bounds().Dx(), img.Bounds().Dy()))
 
 	img, err = cutter.Crop(img, cutter.Config{
 		Width:   1,
@@ -38,7 +37,7 @@ func CompressImage(buffer string) (string, error) {
 	}
 
 	img = resize.Thumbnail(500, 500, img, resize.Lanczos3)
-	logger.Info(fmt.Sprintf("(post) width: %d, height: %d", img.Bounds().Dx(), img.Bounds().Dy()))
+	logger.Debug(fmt.Sprintf("(image) (post) width: %d, height: %d", img.Bounds().Dx(), img.Bounds().Dy()))
 
 	var buf bytes.Buffer
 
@@ -46,7 +45,7 @@ func CompressImage(buffer string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "can't encode image as jpg")
 	}
-	logger.Info(fmt.Sprintf("len (post): %d", len(buf.Bytes())))
+	logger.Debug(fmt.Sprintf("(image) (post) len: %d", len(buf.Bytes())))
 
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }

--- a/apigateway/internal/v1router/handler/shop.go
+++ b/apigateway/internal/v1router/handler/shop.go
@@ -1,6 +1,7 @@
 package v1handler
 
 import (
+	"github.com/GrabItYourself/giys-backend/apigateway/internal/utils"
 	"github.com/GrabItYourself/giys-backend/apigateway/internal/v1router/types"
 	"github.com/GrabItYourself/giys-backend/auth/pkg/authutils"
 	"github.com/GrabItYourself/giys-backend/payment/pkg/paymentproto"
@@ -55,6 +56,14 @@ func (h *Handler) HandleCreateShop(c *fiber.Ctx, shop *shopproto.CreateShopReque
 		return nil, fiber.NewError(fiber.StatusInternalServerError, errors.Wrap(err, "can't embed identity to grpc context").Error())
 	}
 
+	if shop.Image != nil {
+		image, err := utils.CompressImage(*shop.Image)
+		if err != nil {
+			return nil, fiber.NewError(fiber.StatusInternalServerError, errors.Wrap(err, "failed to compress image").Error())
+		}
+		shop.Image = &image
+	}
+
 	res, err := h.Grpc.Shop.CreateShop(ctx, shop)
 	if err != nil {
 		return nil, fiber.NewError(fiber.StatusInternalServerError, errors.Wrap(err, "Failed to request GRPC shop").Error())
@@ -74,6 +83,14 @@ func (h *Handler) HandleEditShop(c *fiber.Ctx, shopId int32, editedShop *shoppro
 
 	if shopId != editedShop.Id {
 		return nil, fiber.NewError(fiber.StatusBadRequest, "shopId params is not the same as shopId in body")
+	}
+
+	if editedShop.Image != nil {
+		image, err := utils.CompressImage(*editedShop.Image)
+		if err != nil {
+			return nil, fiber.NewError(fiber.StatusInternalServerError, errors.Wrap(err, "failed to compress image").Error())
+		}
+		editedShop.Image = &image
 	}
 
 	res, err := h.Grpc.Shop.EditShop(ctx, &shopproto.EditShopRequest{

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/gofiber/fiber/v2 v2.38.1
 	github.com/google/uuid v1.1.2
 	github.com/jackc/pgconn v1.13.0
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+	github.com/oliamb/cutter v0.2.2
 	github.com/omise/omise-go v1.0.8
 	github.com/pkg/errors v0.9.1
 	github.com/rabbitmq/amqp091-go v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -279,7 +279,11 @@ github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/oliamb/cutter v0.2.2 h1:Lfwkya0HHNU1YLnGv2hTkzHfasrSMkgv4Dn+5rmlk3k=
+github.com/oliamb/cutter v0.2.2/go.mod h1:4BenG2/4GuRBDbVm/OPahDVqbrOemzpPiG5mi1iryBU=
 github.com/omise/omise-go v1.0.8 h1:xn7vVFyzvmh0QJ7WS8149zgx1xOcftvH81GEuEXfJ2Y=
 github.com/omise/omise-go v1.0.8/go.mod h1:zAupNC0wZf+QJ/yz+d39z4g8k4UEeFZP7GhiZZTq5XY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=


### PR DESCRIPTION
Currently, the grpc would break if the response is larger than 4 MB. This is the case when get shops return images of all shops (which is ridiculously large). This PR reduces the size of uploaded images drastically (<100 kb/image) by cropping 1:1 at the center and resizing to 500x500.

![image](https://user-images.githubusercontent.com/24814968/201515017-bf154659-e4a5-43c2-9d73-c06364f15b56.png)

The image compression function is applied in shop and shopItem create/update
